### PR TITLE
Allow pecl to run in docker image

### DIFF
--- a/traefik-nginx-wordpress-sql-redis/conf/php.ini
+++ b/traefik-nginx-wordpress-sql-redis/conf/php.ini
@@ -1,7 +1,7 @@
 memory_limit = 256M
 upload_max_filesize = 16M
 post_max_size = 8M
-open_basedir = /var/www/html:/tmp
+open_basedir = /var/www/html:/tmp:/usr/local/lib/php
 display_errors = 0
 display_startup_errors = 0
 register_globals = Off


### PR DESCRIPTION
This is required to run pecl inside the docker image, to install phpredis for a plugin. Doesn't seem harmful afaik.