### PR TITLE
Wordpress stack : share TZ with containers and NGINX tweak for fail2ban integration

### DIFF
--- a/traefik-nginx-wordpress-sql-redis/conf/nginx-wp/nginx.conf
+++ b/traefik-nginx-wordpress-sql-redis/conf/nginx-wp/nginx.conf
@@ -13,6 +13,10 @@ http {
   tcp_nopush   on;
   server_names_hash_bucket_size 128;
 
+############## Let NGINX see client real IPs
+  real_ip_header X-Forwarded-For;
+  set_real_ip_from traefik;
+    
 ############## NGINX security
   server_tokens off;
   proxy_hide_header X-Powered-By;

--- a/traefik-nginx-wordpress-sql-redis/docker-compose.yml
+++ b/traefik-nginx-wordpress-sql-redis/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - 443:443
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /etc/localtime:/etc/localtime:ro
       - ./conf/traefik.yml:/etc/traefik/traefik.yml:ro
       - ./conf/traefikdynamic:/traefikdynamic:ro
       - ./logs/traefik.log:/etc/traefik/applog.log
@@ -24,6 +25,7 @@ services:
     volumes:
       - ./conf/custom-mysql.cnf:/etc/mysql/conf.d/custom-mysql.cnf
       - datasqlwp:/var/lib/mysql
+      - /etc/localtime:/etc/localtime:ro
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQLROOT}
       MYSQL_USER: ${MYSQLUSER}
@@ -37,6 +39,7 @@ services:
     volumes:
       - datawp:/var/www/html
       - datanginxlogs:/var/log/nginx/
+      - /etc/localtime:/etc/localtime:ro
       - ./conf/nginx-wp:/etc/nginx/
     links:
       - wp
@@ -47,6 +50,7 @@ services:
     restart: unless-stopped
     volumes:
       - ./conf/php.ini:/usr/local/etc/php/conf.d/custom.ini
+      - /etc/localtime:/etc/localtime:ro
       - datawp:/var/www/html
     depends_on:
       - sqlwp


### PR DESCRIPTION
Hi

Thanks for sharing your stack, it became mine at first run!!

I always set fail2ban jails for my docker stack as soon as their is a public login form, those few extra lines made it possible because as you must know fail2ban parse logs based on fail regex, IP and time

I thought this PR wouldn't break any already running stack and could only make it safer for paranoid people like me 